### PR TITLE
Add sha512 algorithm

### DIFF
--- a/patch/kconfig-inclusions
+++ b/patch/kconfig-inclusions
@@ -1,6 +1,7 @@
 [common]
 CONFIG_LOG_BUF_SHIFT=20
 CONFIG_RTC_INTF_DEV_UIE_EMUL=y
+CONFIG_CRYPTO_SHA512=y
 ###-> mellanox_common-start
 ###-> mellanox_common-end
 


### PR DESCRIPTION
Add CONFIG_CRYPTO_SHA512  kernel configuration to the default kconfig inclusions, This is used to prevent the following error logs:
```
ERR kernel: [    0.922382] ima: Can not allocate sha384 (reason: -2)
ERR kernel: [    1.047402] ima: No suitable TPM algorithm for boot aggregate
```
On systems which use the SHA384/512 algorithms 
